### PR TITLE
feat(camera_web)!: use flutter camera platform interface

### DIFF
--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -16,8 +16,6 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  camera_platform_interface:
-    path: ../camera_platform_interface
   camera_web:
     path: ../camera_web
 

--- a/packages/camera/camera_web/lib/src/camera_web.dart
+++ b/packages/camera/camera_web/lib/src/camera_web.dart
@@ -69,12 +69,15 @@ class CameraPlugin extends CameraPlatform {
   @override
   Stream<DeviceOrientationChangedEvent> onDeviceOrientationChanged() {
     throw UnimplementedError(
-        'onDeviceOrientationChanged() is not implemented.');
+      'onDeviceOrientationChanged() is not implemented.',
+    );
   }
 
   @override
   Future<void> lockCaptureOrientation(
-      int cameraId, DeviceOrientation orientation) {
+    int cameraId,
+    DeviceOrientation orientation,
+  ) {
     throw UnimplementedError('lockCaptureOrientation() is not implemented.');
   }
 

--- a/packages/camera/camera_web/lib/src/camera_web.dart
+++ b/packages/camera/camera_web/lib/src/camera_web.dart
@@ -1,13 +1,11 @@
 import 'dart:async';
 import 'dart:html' as html;
-import 'dart:ui' as ui;
+import 'dart:math';
 
 import 'package:camera_platform_interface/camera_platform_interface.dart';
-import 'package:camera_web/camera_web.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
-
-String _getViewType(int cameraId) => 'plugins.flutter.io/camera_$cameraId';
 
 /// The web implementation of [CameraPlatform].
 ///
@@ -18,213 +16,170 @@ class CameraPlugin extends CameraPlatform {
     CameraPlatform.instance = CameraPlugin();
   }
 
-  final _cameras = <int, Camera>{};
-  var _textureCounter = 1;
-
   @visibleForTesting
   html.Window? window;
 
   @override
-  Future<void> init() async {
-    _disposeAllCameras();
+  Future<List<CameraDescription>> availableCameras() {
+    throw UnimplementedError('availableCameras() is not implemented.');
   }
 
   @override
-  Future<void> dispose(int textureId) async {
-    _cameras[textureId]!.dispose();
-    _cameras.remove(textureId);
+  Future<int> createCamera(
+    CameraDescription cameraDescription,
+    ResolutionPreset? resolutionPreset, {
+    bool enableAudio = false,
+  }) {
+    throw UnimplementedError('createCamera() is not implemented.');
   }
 
   @override
-  Future<int> create(CameraOptions options) async {
-    final textureId = _textureCounter;
-    _textureCounter++;
-
-    final camera = Camera(
-      options: options,
-      textureId: textureId,
-      window: window,
-    );
-    await camera.initialize();
-
-    _cameras[textureId] = camera;
-    return textureId;
+  Future<void> initializeCamera(
+    int cameraId, {
+    ImageFormatGroup imageFormatGroup = ImageFormatGroup.unknown,
+  }) {
+    throw UnimplementedError('initializeCamera() is not implemented.');
   }
 
   @override
-  Widget buildView(int textureId) {
-    return HtmlElementView(viewType: _getViewType(textureId));
+  Stream<CameraInitializedEvent> onCameraInitialized(int cameraId) {
+    throw UnimplementedError('onCameraInitialized() is not implemented.');
   }
 
   @override
-  Future<void> play(int textureId) => _cameras[textureId]!.play();
-
-  @override
-  Future<void> stop(int textureId) async => _cameras[textureId]!.stop();
-
-  @override
-  Future<CameraImage> takePicture(int textureId) {
-    return _cameras[textureId]!.takePicture();
-  }
-
-  void _disposeAllCameras() {
-    for (final camera in _cameras.values) {
-      camera.dispose();
-    }
-    _cameras.clear();
+  Stream<CameraResolutionChangedEvent> onCameraResolutionChanged(int cameraId) {
+    throw UnimplementedError('onCameraResolutionChanged() is not implemented.');
   }
 
   @override
-  Future<List<MediaDeviceInfo>> getMediaDevices() async {
-    final videoDevices = <MediaDeviceInfo>[];
-    if (html.window.navigator.mediaDevices != null) {
-      final devices =
-          await html.window.navigator.mediaDevices?.enumerateDevices() ?? [];
-      for (var deviceIndex = 0; deviceIndex < devices.length; deviceIndex++) {
-        dynamic device = devices[deviceIndex];
-        if (device is html.MediaDeviceInfo && device.kind == 'videoinput') {
-          videoDevices.add(
-              MediaDeviceInfo(deviceId: device.deviceId, label: device.label));
-        }
-      }
-    }
-    return videoDevices;
+  Stream<CameraClosingEvent> onCameraClosing(int cameraId) {
+    throw UnimplementedError('onCameraClosing() is not implemented.');
   }
 
   @override
-  Future<String?> getDefaultDeviceId() async {
-    String? defaultId = VideoConstraints.defaultDeviceId;
-    if (browserEngine != BrowserEngine.blink) {
-      /// For browsers other than Chrome, enumerate video devices and return
-      /// first one since it is the default selected for the browser.
-      final devices = await getMediaDevices();
-      if (devices.isNotEmpty) {
-        defaultId = devices[0].deviceId;
-      }
-    }
-    return defaultId;
-  }
-}
-
-class Camera {
-  Camera({
-    required this.textureId,
-    this.options = const CameraOptions(),
-    html.Window? window,
-  }) : window = window ?? html.window;
-
-  late html.VideoElement videoElement;
-  late html.DivElement divElement;
-  final CameraOptions options;
-  final int textureId;
-  final html.Window window;
-
-  Future<void> initialize() async {
-    final isSupported = window.navigator.mediaDevices?.getUserMedia != null;
-    if (!isSupported) {
-      throw const CameraNotSupportedException();
-    }
-
-    videoElement = html.VideoElement()..applyDefaultStyles();
-    divElement = html.DivElement()
-      ..style.setProperty('object-fit', 'cover')
-      ..append(videoElement);
-    // ignore: avoid_dynamic_calls
-    ui.platformViewRegistry.registerViewFactory(
-      _getViewType(textureId),
-      (_) => divElement,
-    );
-
-    final stream = await _getMediaStream();
-    videoElement
-      ..autoplay = false
-      ..muted = !options.audio.enabled
-      ..srcObject = stream
-      ..setAttribute('playsinline', '');
+  Stream<CameraErrorEvent> onCameraError(int cameraId) {
+    throw UnimplementedError('onCameraError() is not implemented.');
   }
 
-  Future<html.MediaStream> _getMediaStream() async {
-    try {
-      final constraints = await options.toJson();
-      return await window.navigator.mediaDevices!.getUserMedia(
-        constraints,
-      );
-    } on html.DomException catch (e) {
-      switch (e.name) {
-        case 'NotFoundError':
-        case 'DevicesNotFoundError':
-          throw const CameraNotFoundException();
-        case 'NotReadableError':
-        case 'TrackStartError':
-          throw const CameraNotReadableException();
-        case 'OverconstrainedError':
-        case 'ConstraintNotSatisfiedError':
-          throw const CameraOverconstrainedException();
-        case 'NotAllowedError':
-        case 'PermissionDeniedError':
-          throw const CameraNotAllowedException();
-        case 'TypeError':
-          throw const CameraTypeException();
-        default:
-          throw const CameraUnknownException();
-      }
-    } catch (_) {
-      throw const CameraUnknownException();
-    }
+  @override
+  Stream<VideoRecordedEvent> onVideoRecordedEvent(int cameraId) {
+    throw UnimplementedError('onVideoRecordedEvent() is not implemented.');
   }
 
-  Future<void> play() async {
-    if (videoElement.srcObject == null) {
-      final stream = await _getMediaStream();
-      videoElement.srcObject = stream;
-    }
-    await videoElement.play();
+  @override
+  Stream<DeviceOrientationChangedEvent> onDeviceOrientationChanged() {
+    throw UnimplementedError(
+        'onDeviceOrientationChanged() is not implemented.');
   }
 
-  void stop() {
-    final tracks = videoElement.srcObject?.getVideoTracks();
-    if (tracks != null) {
-      for (final track in tracks) {
-        track.stop();
-      }
-    }
-    videoElement.srcObject = null;
+  @override
+  Future<void> lockCaptureOrientation(
+      int cameraId, DeviceOrientation orientation) {
+    throw UnimplementedError('lockCaptureOrientation() is not implemented.');
   }
 
-  void dispose() {
-    stop();
-    videoElement
-      ..srcObject = null
-      ..load();
+  @override
+  Future<void> unlockCaptureOrientation(int cameraId) {
+    throw UnimplementedError('unlockCaptureOrientation() is not implemented.');
   }
 
-  Future<CameraImage> takePicture() async {
-    final videoWidth = videoElement.videoWidth;
-    final videoHeight = videoElement.videoHeight;
-    final canvas = html.CanvasElement(width: videoWidth, height: videoHeight);
-    canvas.context2D
-      ..translate(videoWidth, 0)
-      ..scale(-1, 1)
-      ..drawImageScaled(videoElement, 0, 0, videoWidth, videoHeight);
-    final blob = await canvas.toBlob();
-    return CameraImage(
-      data: html.Url.createObjectUrl(blob),
-      width: videoWidth,
-      height: videoHeight,
-    );
+  @override
+  Future<XFile> takePicture(int cameraId) {
+    throw UnimplementedError('takePicture() is not implemented.');
   }
-}
 
-extension on html.VideoElement {
-  void applyDefaultStyles() {
-    style
-      ..removeProperty('transform-origin')
-      ..setProperty('pointer-events', 'none')
-      ..setProperty('width', '100%')
-      ..setProperty('height', '100%')
-      ..setProperty('transform', 'scaleX(-1)')
-      ..setProperty('object-fit', 'cover')
-      ..setProperty('-webkit-transform', 'scaleX(-1)')
-      ..setProperty('-moz-transform', 'scaleX(-1)');
+  @override
+  Future<void> prepareForVideoRecording() {
+    throw UnimplementedError('prepareForVideoRecording() is not implemented.');
+  }
+
+  @override
+  Future<void> startVideoRecording(int cameraId, {Duration? maxVideoDuration}) {
+    throw UnimplementedError('startVideoRecording() is not implemented.');
+  }
+
+  @override
+  Future<XFile> stopVideoRecording(int cameraId) {
+    throw UnimplementedError('stopVideoRecording() is not implemented.');
+  }
+
+  @override
+  Future<void> pauseVideoRecording(int cameraId) {
+    throw UnimplementedError('pauseVideoRecording() is not implemented.');
+  }
+
+  @override
+  Future<void> resumeVideoRecording(int cameraId) {
+    throw UnimplementedError('resumeVideoRecording() is not implemented.');
+  }
+
+  @override
+  Future<void> setFlashMode(int cameraId, FlashMode mode) {
+    throw UnimplementedError('setFlashMode() is not implemented.');
+  }
+
+  @override
+  Future<void> setExposureMode(int cameraId, ExposureMode mode) {
+    throw UnimplementedError('setExposureMode() is not implemented.');
+  }
+
+  @override
+  Future<void> setExposurePoint(int cameraId, Point<double>? point) {
+    throw UnimplementedError('setExposurePoint() is not implemented.');
+  }
+
+  @override
+  Future<double> getMinExposureOffset(int cameraId) {
+    throw UnimplementedError('getMinExposureOffset() is not implemented.');
+  }
+
+  @override
+  Future<double> getMaxExposureOffset(int cameraId) {
+    throw UnimplementedError('getMaxExposureOffset() is not implemented.');
+  }
+
+  @override
+  Future<double> getExposureOffsetStepSize(int cameraId) {
+    throw UnimplementedError('getExposureOffsetStepSize() is not implemented.');
+  }
+
+  @override
+  Future<double> setExposureOffset(int cameraId, double offset) {
+    throw UnimplementedError('setExposureOffset() is not implemented.');
+  }
+
+  @override
+  Future<void> setFocusMode(int cameraId, FocusMode mode) {
+    throw UnimplementedError('setFocusMode() is not implemented.');
+  }
+
+  @override
+  Future<void> setFocusPoint(int cameraId, Point<double>? point) {
+    throw UnimplementedError('setFocusPoint() is not implemented.');
+  }
+
+  @override
+  Future<double> getMaxZoomLevel(int cameraId) {
+    throw UnimplementedError('getMaxZoomLevel() is not implemented.');
+  }
+
+  @override
+  Future<double> getMinZoomLevel(int cameraId) {
+    throw UnimplementedError('getMinZoomLevel() is not implemented.');
+  }
+
+  @override
+  Future<void> setZoomLevel(int cameraId, double zoom) {
+    throw UnimplementedError('setZoomLevel() is not implemented.');
+  }
+
+  @override
+  Widget buildPreview(int cameraId) {
+    throw UnimplementedError('buildPreview() is not implemented.');
+  }
+
+  @override
+  Future<void> dispose(int cameraId) {
+    throw UnimplementedError('dispose() is not implemented.');
   }
 }

--- a/packages/camera/camera_web/pubspec.yaml
+++ b/packages/camera/camera_web/pubspec.yaml
@@ -19,8 +19,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  camera_platform_interface:
-    path: ../camera_platform_interface
+  camera_platform_interface: ^2.0.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/camera/camera_web/test/src/camera_web_test.dart
+++ b/packages/camera/camera_web/test/src/camera_web_test.dart
@@ -3,7 +3,7 @@
 import 'dart:html';
 import 'package:camera_platform_interface/camera_platform_interface.dart';
 import 'package:camera_web/camera_web.dart';
-import 'package:flutter/widgets.dart' show Widget;
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -15,7 +15,8 @@ class MockMediaDevices extends Mock implements MediaDevices {}
 
 void main() {
   group('Camera', () {
-    late int textureId;
+    const cameraId = 0;
+
     late Window window;
     late Navigator navigator;
     late MediaDevices mediaDevices;
@@ -36,47 +37,260 @@ void main() {
         () => mediaDevices.getUserMedia(any()),
       ).thenAnswer((_) async => videoElement.captureStream());
       CameraPlatform.instance = CameraPlugin()..window = window;
-      textureId = (await CameraPlatform.instance.create(const CameraOptions()));
     });
 
     testWidgets('$CameraPlugin is the live instance', (tester) async {
       expect(CameraPlatform.instance, isA<CameraPlugin>());
     });
 
-    test('can init', () {
-      expect(CameraPlatform.instance.init(), completes);
-    });
-
-    test('can dispose', () {
-      expect(CameraPlatform.instance.dispose(textureId), completes);
-    });
-
-    test('can play', () async {
-      expect(CameraPlatform.instance.play(textureId), completes);
-    });
-
-    test('can stop', () async {
-      expect(CameraPlatform.instance.stop(textureId), completes);
-    });
-
-    test('can takePicture', () async {
-      await CameraPlatform.instance.play(textureId);
-      expect(CameraPlatform.instance.takePicture(textureId), completes);
-    });
-
-    test('can build view', () {
+    test('availableCameras throws UnimplementedError', () {
       expect(
-        CameraPlatform.instance.buildView(textureId),
-        isInstanceOf<Widget>(),
+        () => CameraPlatform.instance.availableCameras(),
+        throwsUnimplementedError,
       );
     });
 
-    test('can getMediaDevices', () {
-      expect(CameraPlatform.instance.getMediaDevices(), completes);
+    test('createCamera throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.createCamera(
+          CameraDescription(
+            name: 'name',
+            lensDirection: CameraLensDirection.external,
+            sensorOrientation: 0,
+          ),
+          ResolutionPreset.medium,
+        ),
+        throwsUnimplementedError,
+      );
     });
 
-    test('can getDefaultDeviceId', () {
-      expect(CameraPlatform.instance.getDefaultDeviceId(), completes);
+    test('initializeCamera throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.initializeCamera(cameraId),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('lockCaptureOrientation throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.lockCaptureOrientation(
+          cameraId,
+          DeviceOrientation.landscapeLeft,
+        ),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('unlockCaptureOrientation throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.unlockCaptureOrientation(cameraId),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('takePicture throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.takePicture(cameraId),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('prepareForVideoRecording throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.prepareForVideoRecording(),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('startVideoRecording throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.startVideoRecording(cameraId),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('stopVideoRecording throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.stopVideoRecording(cameraId),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('pauseVideoRecording throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.pauseVideoRecording(cameraId),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('resumeVideoRecording throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.resumeVideoRecording(cameraId),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('setFlashMode throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.setFlashMode(
+          cameraId,
+          FlashMode.auto,
+        ),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('setExposureMode throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.setExposureMode(
+          cameraId,
+          ExposureMode.auto,
+        ),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('setExposurePoint throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.setExposurePoint(
+          cameraId,
+          const Point(0, 0),
+        ),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('getMinExposureOffset throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.getMinExposureOffset(cameraId),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('getMaxExposureOffset throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.getMaxExposureOffset(cameraId),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('getExposureOffsetStepSize throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.getExposureOffsetStepSize(cameraId),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('setExposureOffset throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.setExposureOffset(
+          cameraId,
+          0,
+        ),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('setFocusMode throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.setFocusMode(
+          cameraId,
+          FocusMode.auto,
+        ),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('setFocusPoint throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.setFocusPoint(
+          cameraId,
+          const Point(0, 0),
+        ),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('getMaxZoomLevel throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.getMaxZoomLevel(cameraId),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('getMinZoomLevel throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.getMinZoomLevel(cameraId),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('setZoomLevel throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.setZoomLevel(
+          cameraId,
+          1.0,
+        ),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('buildPreview throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.buildPreview(cameraId),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('dispose throws UnimplementedError', () {
+      expect(
+        () => CameraPlatform.instance.dispose(cameraId),
+        throwsUnimplementedError,
+      );
+    });
+
+    group('events', () {
+      test('onCameraInitialized throws UnimplementedError', () {
+        expect(
+          () => CameraPlatform.instance.onCameraInitialized(cameraId),
+          throwsUnimplementedError,
+        );
+      });
+
+      test('onCameraResolutionChanged throws UnimplementedError', () {
+        expect(
+          () => CameraPlatform.instance.onCameraResolutionChanged(cameraId),
+          throwsUnimplementedError,
+        );
+      });
+
+      test('onCameraClosing throws UnimplementedError', () {
+        expect(
+          () => CameraPlatform.instance.onCameraClosing(cameraId),
+          throwsUnimplementedError,
+        );
+      });
+
+      test('onCameraError throws UnimplementedError', () {
+        expect(
+          () => CameraPlatform.instance.onCameraError(cameraId),
+          throwsUnimplementedError,
+        );
+      });
+
+      test('onVideoRecordedEvent throws UnimplementedError', () {
+        expect(
+          () => CameraPlatform.instance.onVideoRecordedEvent(cameraId),
+          throwsUnimplementedError,
+        );
+      });
+
+      test('onDeviceOrientationChanged throws UnimplementedError', () {
+        expect(
+          () => CameraPlatform.instance.onDeviceOrientationChanged(),
+          throwsUnimplementedError,
+        );
+      });
     });
   });
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,7 +105,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.2.0"
   cli_util:
     dependency: transitive
     description:
@@ -641,21 +641,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.17.8"
+    version: "1.17.5"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.28"
+    version: "0.3.25"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## Description

- Replaced photobooth's platform interface with the flutter [camera plugin platform interface](https://github.com/flutter/plugins/blob/master/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart#L26) in `camera_web`.
- Removed [`Camera`](https://github.com/VGVentures/photobooth/compare/main...VGVentures:feat/use-flutter-camera-platform-interface#diff-95b0d214cebd76a613f66fbe94ad5a3cbccd21e0084d34b83b8589d2a14b5ed3L109) class temporarily as it depends on the photobooth's platform interface.
- The web camera plugin now throws an unimplemented error for all methods.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
