### PR TITLE
feat(camera_web): add camera options

### DIFF
--- a/packages/camera/camera_web/lib/src/types/camera_options.dart
+++ b/packages/camera/camera_web/lib/src/types/camera_options.dart
@@ -74,8 +74,8 @@ class FacingModeConstraint {
 
   Object? toJson() {
     return {
-      if (ideal != null) 'ideal': ideal,
-      if (exact != null) 'exact': exact,
+      if (ideal != null) 'ideal': ideal.toString(),
+      if (exact != null) 'exact': exact.toString(),
     };
   }
 }

--- a/packages/camera/camera_web/lib/src/types/camera_options.dart
+++ b/packages/camera/camera_web/lib/src/types/camera_options.dart
@@ -20,19 +20,19 @@ class CameraOptions {
 }
 
 enum CameraType { rear, user }
-enum Constrain { exact, ideal }
+enum Constraint { exact, ideal }
 
 class FacingMode {
-  const FacingMode({this.constrain, this.type});
-  final Constrain? constrain;
+  const FacingMode({this.constraint, this.type});
+  final Constraint? constraint;
   final CameraType? type;
 
   Object? toJson() {
-    if (constrain == null) {
+    if (constraint == null) {
       return type != null ? describeEnum(type!) : null;
     }
     return {
-      describeEnum(constrain!): describeEnum(type!),
+      describeEnum(constraint!): describeEnum(type!),
     };
   }
 }

--- a/packages/camera/camera_web/lib/src/types/camera_options.dart
+++ b/packages/camera/camera_web/lib/src/types/camera_options.dart
@@ -48,8 +48,8 @@ enum Constraint {
 }
 
 /// Indicates the direction in which the desired camera should be pointing.
-class FacingMode {
-  const FacingMode({this.constraint, this.type});
+class FacingModeConstraint {
+  const FacingModeConstraint({this.constraint, this.type});
 
   final Constraint? constraint;
   final CameraType? type;
@@ -85,9 +85,9 @@ class VideoConstraints {
   });
 
   final bool enabled;
-  final FacingMode? facingMode;
-  final VideoSize? width;
-  final VideoSize? height;
+  final FacingModeConstraint? facingMode;
+  final VideoSizeConstraint? width;
+  final VideoSizeConstraint? height;
   final String? deviceId;
 
   Object toJson() {
@@ -109,8 +109,8 @@ class VideoConstraints {
 /// The obtained camera will have a size between [minimum] and [maximum]
 /// with ideally a size of [ideal]. The size is determined by
 /// the capabilities of the hardware and the other specified constraints.
-class VideoSize {
-  const VideoSize({this.minimum, this.ideal, this.maximum});
+class VideoSizeConstraint {
+  const VideoSizeConstraint({this.minimum, this.ideal, this.maximum});
   final int? minimum;
   final int? ideal;
   final int? maximum;

--- a/packages/camera/camera_web/lib/src/types/camera_options.dart
+++ b/packages/camera/camera_web/lib/src/types/camera_options.dart
@@ -1,5 +1,13 @@
 import 'package:flutter/foundation.dart';
 
+/// Options used to create a camera with the given
+/// [audio] and [video] constraints.
+///
+/// These options represent web `MediaStreamConstraints`
+/// and can be used to request the browser for media streams
+/// with tracks the requested types of media.
+///
+/// https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamConstraints
 class CameraOptions {
   const CameraOptions({
     AudioConstraints? audio,
@@ -19,11 +27,31 @@ class CameraOptions {
   }
 }
 
-enum CameraType { rear, user }
-enum Constraint { exact, ideal }
+enum CameraType {
+  /// The camera is facing away from the user, viewing their environment.
+  /// This includes the back camera on a smartphone.
+  environment,
 
+  /// The video source is facing toward the user.
+  /// This includes the front camera on a smartphone.
+  user
+}
+
+/// Specifies a constraint of a property value.
+enum Constraint {
+  /// Used to specify a value that the property must have
+  /// to be considered acceptable.
+  exact,
+
+  /// Used to specify a value the property would ideally have,
+  /// but which can be considered optional.
+  ideal
+}
+
+/// Indicates the direction in which the desired camera should be pointing.
 class FacingMode {
   const FacingMode({this.constraint, this.type});
+
   final Constraint? constraint;
   final CameraType? type;
 
@@ -37,13 +65,17 @@ class FacingMode {
   }
 }
 
+/// Indicates whether the audio track is requested.
 class AudioConstraints {
   const AudioConstraints({this.enabled = false});
+
   final bool enabled;
 
   Object toJson() => enabled;
 }
 
+/// Indicates whether the video track is requested.
+/// Includes optional constraints that the video track must have.
 class VideoConstraints {
   const VideoConstraints({
     this.enabled = true,
@@ -72,6 +104,12 @@ class VideoConstraints {
   }
 }
 
+/// The size of the requested video track used in
+/// [VideoConstraints.width] and [VideoConstraints.height].
+///
+/// The obtained camera will have a size between [minimum] and [maximum]
+/// with ideally a size of [ideal]. The size is determined by
+/// the capabilities of the hardware and the other specified constraints.
 class VideoSize {
   const VideoSize({this.minimum, this.ideal, this.maximum});
   final int? minimum;

--- a/packages/camera/camera_web/lib/src/types/camera_options.dart
+++ b/packages/camera/camera_web/lib/src/types/camera_options.dart
@@ -1,7 +1,5 @@
-import 'package:flutter/foundation.dart';
-
 /// Options used to create a camera with the given
-/// [audio] and [video] constraints.
+/// [audio] and [video] media constraints.
 ///
 /// These options represent web `MediaStreamConstraints`
 /// and can be used to request the browser for media streams
@@ -9,6 +7,8 @@ import 'package:flutter/foundation.dart';
 ///
 /// https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamConstraints
 class CameraOptions {
+  /// Creates a new instance of [CameraOptions]
+  /// with the given [audio] and [video] constraints.
   const CameraOptions({
     AudioConstraints? audio,
     VideoConstraints? video,
@@ -47,36 +47,46 @@ class CameraType {
   static const CameraType user = CameraType._('user');
 }
 
-/// Specifies a constraint of a property value.
-enum Constraint {
-  /// Used to specify a value that the property must have
-  /// to be considered acceptable.
-  exact,
-
-  /// Used to specify a value the property would ideally have,
-  /// but which can be considered optional.
-  ideal
-}
-
 /// Indicates the direction in which the desired camera should be pointing.
 class FacingModeConstraint {
-  const FacingModeConstraint({this.constraint, this.type});
+  /// Creates a new instance of [FacingModeConstraint]
+  /// with the given [ideal] and [exact] constraints.
+  const FacingModeConstraint._({this.ideal, this.exact});
 
-  final Constraint? constraint;
-  final CameraType? type;
+  /// Creates a new instance of [FacingModeConstraint]
+  /// with [ideal] constraint set to [type].
+  ///
+  /// If this constraint is used, then the camera would ideally have
+  /// the desired facing [type] but it may be considered optional.
+  factory FacingModeConstraint(CameraType type) =>
+      FacingModeConstraint._(ideal: type);
+
+  /// Creates a new instance of [FacingModeConstraint]
+  /// with [exact] constraint set to [type].
+  ///
+  /// If this constraint is used, then the camera must have
+  /// the desired facing [type] to be considered acceptable.
+  factory FacingModeConstraint.exact(CameraType type) =>
+      FacingModeConstraint._(exact: type);
+
+  final CameraType? ideal;
+  final CameraType? exact;
 
   Object? toJson() {
-    if (constraint == null) {
-      return type != null ? describeEnum(type!) : null;
-    }
     return {
-      describeEnum(constraint!): describeEnum(type!),
+      if (ideal != null) 'ideal': ideal,
+      if (exact != null) 'exact': exact,
     };
   }
 }
 
 /// Indicates whether the audio track is requested.
+///
+/// By default, the audio track is not requested.
 class AudioConstraints {
+  /// Creates a new instance of [AudioConstraints]
+  /// with the given [enabled] constraint
+  /// indicating whether the audio track is requested.
   const AudioConstraints({this.enabled = false});
 
   final bool enabled;
@@ -85,8 +95,12 @@ class AudioConstraints {
 }
 
 /// Indicates whether the video track is requested.
-/// Includes optional constraints that the video track must have.
+///
+/// Includes optional constraints that the video track must have
+/// to be considered acceptable.
 class VideoConstraints {
+  /// Creates a new instance of [VideoConstraints]
+  /// with the given constraints.
   const VideoConstraints({
     this.enabled = true,
     this.facingMode,
@@ -121,7 +135,10 @@ class VideoConstraints {
 /// with ideally a size of [ideal]. The size is determined by
 /// the capabilities of the hardware and the other specified constraints.
 class VideoSizeConstraint {
+  /// Creates a new instance of [VideoSizeConstraint] with the given
+  /// [minimum], [ideal] and [maximum] constraints.
   const VideoSizeConstraint({this.minimum, this.ideal, this.maximum});
+
   final int? minimum;
   final int? ideal;
   final int? maximum;

--- a/packages/camera/camera_web/lib/src/types/camera_options.dart
+++ b/packages/camera/camera_web/lib/src/types/camera_options.dart
@@ -18,11 +18,10 @@ class CameraOptions {
   final AudioConstraints audio;
   final VideoConstraints video;
 
-  Future<Map<String, dynamic>> toJson() async {
-    final videoConstraints = await video.toJson();
+  Map<String, dynamic> toJson() {
     return {
       'audio': audio.toJson(),
-      'video': videoConstraints,
+      'video': video.toJson(),
     };
   }
 }
@@ -91,7 +90,7 @@ class VideoConstraints {
   final VideoSize? height;
   final String? deviceId;
 
-  Future<Object> toJson() async {
+  Object toJson() {
     if (!enabled) return false;
     final json = <String, dynamic>{};
 

--- a/packages/camera/camera_web/lib/src/types/camera_options.dart
+++ b/packages/camera/camera_web/lib/src/types/camera_options.dart
@@ -5,7 +5,7 @@ import 'package:flutter/foundation.dart';
 ///
 /// These options represent web `MediaStreamConstraints`
 /// and can be used to request the browser for media streams
-/// with tracks the requested types of media.
+/// with the requested types of media.
 ///
 /// https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamConstraints
 class CameraOptions {

--- a/packages/camera/camera_web/lib/src/types/camera_options.dart
+++ b/packages/camera/camera_web/lib/src/types/camera_options.dart
@@ -26,14 +26,25 @@ class CameraOptions {
   }
 }
 
-enum CameraType {
+/// The camera type used in [FacingModeConstraint].
+///
+/// Specifies whether the requested camera should be facing away
+/// or toward the user.
+class CameraType {
+  const CameraType._(this._type);
+
+  final String _type;
+
+  @override
+  String toString() => _type;
+
   /// The camera is facing away from the user, viewing their environment.
   /// This includes the back camera on a smartphone.
-  environment,
+  static const CameraType environment = CameraType._('environment');
 
-  /// The video source is facing toward the user.
+  /// The camera is facing toward the user.
   /// This includes the front camera on a smartphone.
-  user
+  static const CameraType user = CameraType._('user');
 }
 
 /// Specifies a constraint of a property value.

--- a/packages/camera/camera_web/lib/src/types/camera_options.dart
+++ b/packages/camera/camera_web/lib/src/types/camera_options.dart
@@ -94,29 +94,24 @@ class AudioConstraints {
   Object toJson() => enabled;
 }
 
-/// Indicates whether the video track is requested.
-///
-/// Includes optional constraints that the video track must have
+/// Defines constraints that the video track must have
 /// to be considered acceptable.
 class VideoConstraints {
   /// Creates a new instance of [VideoConstraints]
   /// with the given constraints.
   const VideoConstraints({
-    this.enabled = true,
     this.facingMode,
     this.width,
     this.height,
     this.deviceId,
   });
 
-  final bool enabled;
   final FacingModeConstraint? facingMode;
   final VideoSizeConstraint? width;
   final VideoSizeConstraint? height;
   final String? deviceId;
 
   Object toJson() {
-    if (!enabled) return false;
     final json = <String, dynamic>{};
 
     if (width != null) json['width'] = width!.toJson();
@@ -149,6 +144,7 @@ class VideoSizeConstraint {
     if (ideal != null) json['ideal'] = ideal;
     if (minimum != null) json['min'] = minimum;
     if (maximum != null) json['max'] = maximum;
+
     return json;
   }
 }

--- a/packages/camera/camera_web/lib/src/types/camera_options.dart
+++ b/packages/camera/camera_web/lib/src/types/camera_options.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/foundation.dart';
+
+class CameraOptions {
+  const CameraOptions({
+    AudioConstraints? audio,
+    VideoConstraints? video,
+  })  : audio = audio ?? const AudioConstraints(),
+        video = video ?? const VideoConstraints();
+
+  final AudioConstraints audio;
+  final VideoConstraints video;
+
+  Future<Map<String, dynamic>> toJson() async {
+    final videoConstraints = await video.toJson();
+    return {
+      'audio': audio.toJson(),
+      'video': videoConstraints,
+    };
+  }
+}
+
+enum CameraType { rear, user }
+enum Constrain { exact, ideal }
+
+class FacingMode {
+  const FacingMode({this.constrain, this.type});
+  final Constrain? constrain;
+  final CameraType? type;
+
+  Object? toJson() {
+    if (constrain == null) {
+      return type != null ? describeEnum(type!) : null;
+    }
+    return {
+      describeEnum(constrain!): describeEnum(type!),
+    };
+  }
+}
+
+class AudioConstraints {
+  const AudioConstraints({this.enabled = false});
+  final bool enabled;
+
+  Object toJson() => enabled;
+}
+
+class VideoConstraints {
+  const VideoConstraints({
+    this.enabled = true,
+    this.facingMode,
+    this.width,
+    this.height,
+    this.deviceId,
+  });
+
+  final bool enabled;
+  final FacingMode? facingMode;
+  final VideoSize? width;
+  final VideoSize? height;
+  final String? deviceId;
+
+  Future<Object> toJson() async {
+    if (!enabled) return false;
+    final json = <String, dynamic>{};
+
+    if (width != null) json['width'] = width!.toJson();
+    if (height != null) json['height'] = height!.toJson();
+    if (facingMode != null) json['facingMode'] = facingMode!.toJson();
+    if (deviceId != null) json['deviceId'] = deviceId!;
+
+    return json;
+  }
+}
+
+class VideoSize {
+  const VideoSize({this.minimum, this.ideal, this.maximum});
+  final int? minimum;
+  final int? ideal;
+  final int? maximum;
+
+  Object toJson() {
+    final json = <String, dynamic>{};
+
+    if (ideal != null) json['ideal'] = ideal;
+    if (minimum != null) json['min'] = minimum;
+    if (maximum != null) json['max'] = maximum;
+    return json;
+  }
+}

--- a/packages/camera/camera_web/test/src/types/camera_options_test.dart
+++ b/packages/camera/camera_web/test/src/types/camera_options_test.dart
@@ -35,9 +35,9 @@ void main() {
       expect(
         FacingMode(
           constraint: Constraint.ideal,
-          type: CameraType.rear,
+          type: CameraType.environment,
         ).toJson(),
-        equals({'ideal': 'rear'}),
+        equals({'ideal': 'environment'}),
       );
     });
 

--- a/packages/camera/camera_web/test/src/types/camera_options_test.dart
+++ b/packages/camera/camera_web/test/src/types/camera_options_test.dart
@@ -85,24 +85,7 @@ void main() {
   });
 
   group('VideoConstraints', () {
-    test(
-        'serializes correctly '
-        'when enabled is false', () async {
-      expect(
-        VideoConstraints(
-          enabled: false,
-          facingMode: FacingModeConstraint(CameraType.user),
-          width: VideoSizeConstraint(ideal: 100, maximum: 100),
-          height: VideoSizeConstraint(ideal: 50, maximum: 50),
-          deviceId: 'deviceId',
-        ).toJson(),
-        equals(false),
-      );
-    });
-
-    test(
-        'serializes correctly '
-        'when enabled is true', () async {
+    test('serializes correctly', () async {
       final videoConstraints = VideoConstraints(
         facingMode: FacingModeConstraint.exact(CameraType.user),
         width: VideoSizeConstraint(ideal: 100, maximum: 100),

--- a/packages/camera/camera_web/test/src/types/camera_options_test.dart
+++ b/packages/camera/camera_web/test/src/types/camera_options_test.dart
@@ -11,7 +11,7 @@ void main() {
       final cameraOptions = CameraOptions(
         audio: AudioConstraints(enabled: true),
         video: VideoConstraints(
-          facingMode: FacingMode(
+          facingMode: FacingModeConstraint(
             constraint: Constraint.exact,
             type: CameraType.user,
           ),
@@ -28,12 +28,12 @@ void main() {
     });
   });
 
-  group('FacingMode', () {
+  group('FacingModeConstraint', () {
     test(
         'serializes correctly '
         'when constraint and type are given', () {
       expect(
-        FacingMode(
+        FacingModeConstraint(
           constraint: Constraint.ideal,
           type: CameraType.environment,
         ).toJson(),
@@ -45,7 +45,7 @@ void main() {
         'serializes correctly '
         'when only type is given', () {
       expect(
-        FacingMode(
+        FacingModeConstraint(
           type: CameraType.user,
         ).toJson(),
         equals('user'),
@@ -56,7 +56,7 @@ void main() {
         'serializes to null '
         'when no property is given', () {
       expect(
-        FacingMode().toJson(),
+        FacingModeConstraint().toJson(),
         equals(null),
       );
     });
@@ -78,9 +78,9 @@ void main() {
       expect(
         VideoConstraints(
           enabled: false,
-          facingMode: FacingMode(constraint: Constraint.exact),
-          width: VideoSize(ideal: 100, maximum: 100),
-          height: VideoSize(ideal: 50, maximum: 50),
+          facingMode: FacingModeConstraint(constraint: Constraint.exact),
+          width: VideoSizeConstraint(ideal: 100, maximum: 100),
+          height: VideoSizeConstraint(ideal: 50, maximum: 50),
           deviceId: 'deviceId',
         ).toJson(),
         equals(false),
@@ -91,12 +91,12 @@ void main() {
         'serializes correctly '
         'when enabled is true', () async {
       final videoConstraints = VideoConstraints(
-        facingMode: FacingMode(
+        facingMode: FacingModeConstraint(
           constraint: Constraint.exact,
           type: CameraType.user,
         ),
-        width: VideoSize(ideal: 100, maximum: 100),
-        height: VideoSize(ideal: 50, maximum: 50),
+        width: VideoSizeConstraint(ideal: 100, maximum: 100),
+        height: VideoSizeConstraint(ideal: 50, maximum: 50),
         deviceId: 'deviceId',
       );
 
@@ -111,10 +111,10 @@ void main() {
       );
     });
 
-    group('VideoSize', () {
+    group('VideoSizeConstraint', () {
       test('serializes correctly', () {
         expect(
-          VideoSize(
+          VideoSizeConstraint(
             ideal: 400,
             minimum: 200,
             maximum: 400,

--- a/packages/camera/camera_web/test/src/types/camera_options_test.dart
+++ b/packages/camera/camera_web/test/src/types/camera_options_test.dart
@@ -12,7 +12,7 @@ void main() {
         audio: AudioConstraints(enabled: true),
         video: VideoConstraints(
           facingMode: FacingMode(
-            constrain: Constrain.exact,
+            constraint: Constraint.exact,
             type: CameraType.user,
           ),
         ),
@@ -31,10 +31,10 @@ void main() {
   group('FacingMode', () {
     test(
         'serializes correctly '
-        'when constrain and type are given', () {
+        'when constraint and type are given', () {
       expect(
         FacingMode(
-          constrain: Constrain.ideal,
+          constraint: Constraint.ideal,
           type: CameraType.rear,
         ).toJson(),
         equals({'ideal': 'rear'}),
@@ -78,7 +78,7 @@ void main() {
       expect(
         await VideoConstraints(
           enabled: false,
-          facingMode: FacingMode(constrain: Constrain.exact),
+          facingMode: FacingMode(constraint: Constraint.exact),
           width: VideoSize(ideal: 100, maximum: 100),
           height: VideoSize(ideal: 50, maximum: 50),
           deviceId: 'deviceId',
@@ -92,7 +92,7 @@ void main() {
         'when enabled is true', () async {
       final videoConstraints = VideoConstraints(
         facingMode: FacingMode(
-          constrain: Constrain.exact,
+          constraint: Constraint.exact,
           type: CameraType.user,
         ),
         width: VideoSize(ideal: 100, maximum: 100),

--- a/packages/camera/camera_web/test/src/types/camera_options_test.dart
+++ b/packages/camera/camera_web/test/src/types/camera_options_test.dart
@@ -19,10 +19,10 @@ void main() {
       );
 
       expect(
-        await cameraOptions.toJson(),
+        cameraOptions.toJson(),
         equals({
           'audio': cameraOptions.audio.toJson(),
-          'video': await cameraOptions.video.toJson(),
+          'video': cameraOptions.video.toJson(),
         }),
       );
     });
@@ -76,7 +76,7 @@ void main() {
         'serializes correctly '
         'when enabled is false', () async {
       expect(
-        await VideoConstraints(
+        VideoConstraints(
           enabled: false,
           facingMode: FacingMode(constraint: Constraint.exact),
           width: VideoSize(ideal: 100, maximum: 100),
@@ -101,7 +101,7 @@ void main() {
       );
 
       expect(
-        await videoConstraints.toJson(),
+        videoConstraints.toJson(),
         equals({
           'facingMode': videoConstraints.facingMode!.toJson(),
           'width': videoConstraints.width!.toJson(),

--- a/packages/camera/camera_web/test/src/types/camera_options_test.dart
+++ b/packages/camera/camera_web/test/src/types/camera_options_test.dart
@@ -11,10 +11,7 @@ void main() {
       final cameraOptions = CameraOptions(
         audio: AudioConstraints(enabled: true),
         video: VideoConstraints(
-          facingMode: FacingModeConstraint(
-            constraint: Constraint.exact,
-            type: CameraType.user,
-          ),
+          facingMode: FacingModeConstraint.exact(CameraType.user),
         ),
       );
 
@@ -29,36 +26,52 @@ void main() {
   });
 
   group('FacingModeConstraint', () {
-    test(
-        'serializes correctly '
-        'when constraint and type are given', () {
-      expect(
-        FacingModeConstraint(
-          constraint: Constraint.ideal,
-          type: CameraType.environment,
-        ).toJson(),
-        equals({'ideal': 'environment'}),
-      );
+    group('ideal', () {
+      test(
+          'serializes correctly '
+          'for environment camera type', () {
+        expect(
+          FacingModeConstraint(
+            CameraType.environment,
+          ).toJson(),
+          equals({'ideal': 'environment'}),
+        );
+      });
+
+      test(
+          'serializes correctly '
+          'for user camera type', () {
+        expect(
+          FacingModeConstraint(
+            CameraType.user,
+          ).toJson(),
+          equals({'ideal': 'user'}),
+        );
+      });
     });
 
-    test(
-        'serializes correctly '
-        'when only type is given', () {
-      expect(
-        FacingModeConstraint(
-          type: CameraType.user,
-        ).toJson(),
-        equals('user'),
-      );
-    });
+    group('exact', () {
+      test(
+          'serializes correctly '
+          'for environment camera type', () {
+        expect(
+          FacingModeConstraint.exact(
+            CameraType.environment,
+          ).toJson(),
+          equals({'exact': 'environment'}),
+        );
+      });
 
-    test(
-        'serializes to null '
-        'when no property is given', () {
-      expect(
-        FacingModeConstraint().toJson(),
-        equals(null),
-      );
+      test(
+          'serializes correctly '
+          'for user camera type', () {
+        expect(
+          FacingModeConstraint.exact(
+            CameraType.user,
+          ).toJson(),
+          equals({'exact': 'user'}),
+        );
+      });
     });
   });
 
@@ -78,7 +91,7 @@ void main() {
       expect(
         VideoConstraints(
           enabled: false,
-          facingMode: FacingModeConstraint(constraint: Constraint.exact),
+          facingMode: FacingModeConstraint(CameraType.user),
           width: VideoSizeConstraint(ideal: 100, maximum: 100),
           height: VideoSizeConstraint(ideal: 50, maximum: 50),
           deviceId: 'deviceId',
@@ -91,10 +104,7 @@ void main() {
         'serializes correctly '
         'when enabled is true', () async {
       final videoConstraints = VideoConstraints(
-        facingMode: FacingModeConstraint(
-          constraint: Constraint.exact,
-          type: CameraType.user,
-        ),
+        facingMode: FacingModeConstraint.exact(CameraType.user),
         width: VideoSizeConstraint(ideal: 100, maximum: 100),
         height: VideoSizeConstraint(ideal: 50, maximum: 50),
         deviceId: 'deviceId',
@@ -111,7 +121,7 @@ void main() {
       );
     });
 
-    group('VideoSizeConstraint', () {
+    group('VideoSizeConstraint ', () {
       test('serializes correctly', () {
         expect(
           VideoSizeConstraint(

--- a/packages/camera/camera_web/test/src/types/camera_options_test.dart
+++ b/packages/camera/camera_web/test/src/types/camera_options_test.dart
@@ -1,0 +1,131 @@
+// ignore_for_file: prefer_const_constructors
+
+@TestOn('chrome')
+
+import 'package:camera_web/src/types/camera_options.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('CameraOptions', () {
+    test('serializes correctly', () async {
+      final cameraOptions = CameraOptions(
+        audio: AudioConstraints(enabled: true),
+        video: VideoConstraints(
+          facingMode: FacingMode(
+            constrain: Constrain.exact,
+            type: CameraType.user,
+          ),
+        ),
+      );
+
+      expect(
+        await cameraOptions.toJson(),
+        equals({
+          'audio': cameraOptions.audio.toJson(),
+          'video': await cameraOptions.video.toJson(),
+        }),
+      );
+    });
+  });
+
+  group('FacingMode', () {
+    test(
+        'serializes correctly '
+        'when constrain and type are given', () {
+      expect(
+        FacingMode(
+          constrain: Constrain.ideal,
+          type: CameraType.rear,
+        ).toJson(),
+        equals({'ideal': 'rear'}),
+      );
+    });
+
+    test(
+        'serializes correctly '
+        'when only type is given', () {
+      expect(
+        FacingMode(
+          type: CameraType.user,
+        ).toJson(),
+        equals('user'),
+      );
+    });
+
+    test(
+        'serializes to null '
+        'when no property is given', () {
+      expect(
+        FacingMode().toJson(),
+        equals(null),
+      );
+    });
+  });
+
+  group('AudioConstraints', () {
+    test('serializes correctly', () {
+      expect(
+        AudioConstraints(enabled: true).toJson(),
+        equals(true),
+      );
+    });
+  });
+
+  group('VideoConstraints', () {
+    test(
+        'serializes correctly '
+        'when enabled is false', () async {
+      expect(
+        await VideoConstraints(
+          enabled: false,
+          facingMode: FacingMode(constrain: Constrain.exact),
+          width: VideoSize(ideal: 100, maximum: 100),
+          height: VideoSize(ideal: 50, maximum: 50),
+          deviceId: 'deviceId',
+        ).toJson(),
+        equals(false),
+      );
+    });
+
+    test(
+        'serializes correctly '
+        'when enabled is true', () async {
+      final videoConstraints = VideoConstraints(
+        facingMode: FacingMode(
+          constrain: Constrain.exact,
+          type: CameraType.user,
+        ),
+        width: VideoSize(ideal: 100, maximum: 100),
+        height: VideoSize(ideal: 50, maximum: 50),
+        deviceId: 'deviceId',
+      );
+
+      expect(
+        await videoConstraints.toJson(),
+        equals({
+          'facingMode': videoConstraints.facingMode!.toJson(),
+          'width': videoConstraints.width!.toJson(),
+          'height': videoConstraints.height!.toJson(),
+          'deviceId': 'deviceId',
+        }),
+      );
+    });
+
+    group('VideoSize', () {
+      test('serializes correctly', () {
+        expect(
+          VideoSize(
+            ideal: 400,
+            minimum: 200,
+            maximum: 400,
+          ).toJson(),
+          equals({
+            'ideal': 400,
+            'min': 200,
+            'max': 400,
+          }),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

- Added web camera options used to specify audio and video constraints. These options are going to be used when accessing a user media device with [`getUserMedia`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia).

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
