### PR TITLE
feat(camera_web): add camera with options to play, stop and take a picture

### DIFF
--- a/packages/camera/camera_web/lib/src/camera.dart
+++ b/packages/camera/camera_web/lib/src/camera.dart
@@ -1,0 +1,152 @@
+import 'dart:html' as html;
+import 'dart:ui' as ui;
+
+import 'package:camera_platform_interface/camera_platform_interface.dart';
+import 'package:camera_web/src/types/camera_error_codes.dart';
+import 'package:camera_web/src/types/camera_options.dart';
+
+String _getViewType(int cameraId) => 'plugins.flutter.io/camera_$cameraId';
+
+class Camera {
+  Camera({
+    required this.textureId,
+    this.options = const CameraOptions(),
+    html.Window? window,
+  }) : window = window ?? html.window;
+
+  late html.VideoElement videoElement;
+  late html.DivElement divElement;
+  final CameraOptions options;
+  final int textureId;
+  final html.Window window;
+
+  Future<void> initialize() async {
+    final isSupported = window.navigator.mediaDevices?.getUserMedia != null;
+    if (!isSupported) {
+      throw CameraException(
+        CameraErrorCodes.notSupported,
+        'The camera is not supported on this device.',
+      );
+    }
+
+    videoElement = html.VideoElement()..applyDefaultStyles();
+    divElement = html.DivElement()
+      ..style.setProperty('object-fit', 'cover')
+      ..append(videoElement);
+
+    // ignore: avoid_dynamic_calls
+    ui.platformViewRegistry.registerViewFactory(
+      _getViewType(textureId),
+      (_) => divElement,
+    );
+
+    final stream = await _getMediaStream();
+    videoElement
+      ..autoplay = false
+      ..muted = !options.audio.enabled
+      ..srcObject = stream
+      ..setAttribute('playsinline', '');
+  }
+
+  Future<html.MediaStream> _getMediaStream() async {
+    try {
+      final constraints = await options.toJson();
+      return await window.navigator.mediaDevices!.getUserMedia(constraints);
+    } on html.DomException catch (e) {
+      switch (e.name) {
+        case 'NotFoundError':
+        case 'DevicesNotFoundError':
+          throw CameraException(
+            CameraErrorCodes.notFound,
+            'No camera found for the given camera options.',
+          );
+        case 'NotReadableError':
+        case 'TrackStartError':
+          throw CameraException(
+            CameraErrorCodes.notReadable,
+            'The camera is not readable due to a hardware error '
+            'that prevented access to the device.',
+          );
+        case 'OverconstrainedError':
+        case 'ConstraintNotSatisfiedError':
+          throw CameraException(
+            CameraErrorCodes.overconstrained,
+            'Provided camera options are impossible to satisfy.',
+          );
+        case 'NotAllowedError':
+        case 'PermissionDeniedError':
+          throw CameraException(
+            CameraErrorCodes.permissionDenied,
+            'The camera cannot be used or the permission '
+            'to access the camera is not granted.',
+          );
+        case 'TypeError':
+          throw CameraException(
+            CameraErrorCodes.type,
+            'Provided camera options are incorrect.',
+          );
+        default:
+          throw CameraException(
+            CameraErrorCodes.unknown,
+            'An unknown error occured when initializing the camera.',
+          );
+      }
+    } catch (_) {
+      throw CameraException(
+        CameraErrorCodes.unknown,
+        'An unknown error occured when initializing the camera.',
+      );
+    }
+  }
+
+  Future<void> play() async {
+    if (videoElement.srcObject == null) {
+      final stream = await _getMediaStream();
+      videoElement.srcObject = stream;
+    }
+    await videoElement.play();
+  }
+
+  void stop() {
+    final tracks = videoElement.srcObject?.getVideoTracks();
+    if (tracks != null) {
+      for (final track in tracks) {
+        track.stop();
+      }
+    }
+    videoElement.srcObject = null;
+  }
+
+  Future<XFile> takePicture() async {
+    final videoWidth = videoElement.videoWidth;
+    final videoHeight = videoElement.videoHeight;
+    final canvas = html.CanvasElement(width: videoWidth, height: videoHeight);
+    canvas.context2D
+      ..translate(videoWidth, 0)
+      ..scale(-1, 1)
+      ..drawImageScaled(videoElement, 0, 0, videoWidth, videoHeight);
+    final blob = await canvas.toBlob();
+    return XFile(html.Url.createObjectUrl(blob));
+  }
+
+  void dispose() {
+    stop();
+    videoElement
+      ..srcObject = null
+      ..load();
+  }
+}
+
+extension on html.VideoElement {
+  void applyDefaultStyles() {
+    style
+      ..removeProperty('transform-origin')
+      ..setProperty('pointer-events', 'none')
+      ..setProperty('width', '100%')
+      ..setProperty('height', '100%')
+      ..setProperty('object-fit', 'cover')
+      ..setProperty('transform', 'scaleX(-1)')
+      ..setProperty('-webkit-transform', 'scaleX(-1)')
+      ..setProperty('-moz-transform', 'scaleX(-1)');
+  }
+}

--- a/packages/camera/camera_web/lib/src/camera.dart
+++ b/packages/camera/camera_web/lib/src/camera.dart
@@ -7,6 +7,20 @@ import 'package:camera_web/src/types/camera_options.dart';
 
 String _getViewType(int cameraId) => 'plugins.flutter.io/camera_$cameraId';
 
+/// A camera initialized from the media devices in the current [window].
+/// The obtained camera is constrained by the [options] which are used
+/// when querying the media input in [_getMediaStream].
+///
+/// The camera stream is displayed in the [videoElement] wrapped in the
+/// [divElement] to avoid overriding the custom styles applied to
+/// the video element in [_applyDefaultVideoStyles].
+/// See https://github.com/flutter/flutter/issues/79519.
+///
+/// The camera can be played/stopped by calling [play]/[stop]
+/// or may capture a picture by [takePicture].
+///
+/// The [textureId] is used to register a camera view factory with the id
+/// returned by [_getViewType].
 class Camera {
   Camera({
     required this.textureId,

--- a/packages/camera/camera_web/lib/src/camera.dart
+++ b/packages/camera/camera_web/lib/src/camera.dart
@@ -29,7 +29,9 @@ class Camera {
       );
     }
 
-    videoElement = html.VideoElement()..applyDefaultStyles();
+    videoElement = html.VideoElement();
+    _applyDefaultVideoStyles(videoElement);
+
     divElement = html.DivElement()
       ..style.setProperty('object-fit', 'cover')
       ..append(videoElement);
@@ -135,18 +137,14 @@ class Camera {
       ..srcObject = null
       ..load();
   }
-}
 
-extension on html.VideoElement {
-  void applyDefaultStyles() {
-    style
-      ..removeProperty('transform-origin')
-      ..setProperty('pointer-events', 'none')
-      ..setProperty('width', '100%')
-      ..setProperty('height', '100%')
-      ..setProperty('object-fit', 'cover')
-      ..setProperty('transform', 'scaleX(-1)')
-      ..setProperty('-webkit-transform', 'scaleX(-1)')
-      ..setProperty('-moz-transform', 'scaleX(-1)');
+  void _applyDefaultVideoStyles(html.VideoElement element) {
+    element.style
+      ..transformOrigin = 'center'
+      ..pointerEvents = 'none'
+      ..width = '100%'
+      ..height = '100%'
+      ..objectFit = 'cover'
+      ..transform = 'scaleX(-1)';
   }
 }

--- a/packages/camera/camera_web/lib/src/types/camera_error_codes.dart
+++ b/packages/camera/camera_web/lib/src/types/camera_error_codes.dart
@@ -1,0 +1,9 @@
+abstract class CameraErrorCodes {
+  static const notSupported = 'cameraNotSupported';
+  static const notFound = 'cameraNotFound';
+  static const notReadable = 'cameraNotReadable';
+  static const overconstrained = 'cameraOverconstrained';
+  static const permissionDenied = 'cameraPermission';
+  static const type = 'cameraType';
+  static const unknown = 'cameraUnknown';
+}

--- a/packages/camera/camera_web/test/helpers/helpers.dart
+++ b/packages/camera/camera_web/test/helpers/helpers.dart
@@ -1,0 +1,1 @@
+export 'mocks.dart';

--- a/packages/camera/camera_web/test/helpers/mocks.dart
+++ b/packages/camera/camera_web/test/helpers/mocks.dart
@@ -1,0 +1,21 @@
+import 'dart:html';
+
+import 'package:mocktail/mocktail.dart';
+
+class MockWindow extends Mock implements Window {}
+
+class MockNavigator extends Mock implements Navigator {}
+
+class MockMediaDevices extends Mock implements MediaDevices {}
+
+class FakeMediaStreamTrack extends Fake implements MediaStreamTrack {}
+
+/// A fake [DomException] that returns the provided [errorName].
+class FakeDomException extends Fake implements DomException {
+  FakeDomException(this.errorName);
+
+  final String errorName;
+
+  @override
+  String get name => errorName;
+}

--- a/packages/camera/camera_web/test/src/camera_test.dart
+++ b/packages/camera/camera_web/test/src/camera_test.dart
@@ -1,0 +1,479 @@
+// ignore_for_file: prefer_const_constructors
+
+@TestOn('chrome')
+
+import 'dart:html';
+
+import 'package:camera_platform_interface/camera_platform_interface.dart';
+import 'package:camera_web/src/camera.dart';
+import 'package:camera_web/src/types/camera_error_codes.dart';
+import 'package:camera_web/src/types/camera_options.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../helpers/helpers.dart';
+
+void main() {
+  group('Camera', () {
+    late Window window;
+    late Navigator navigator;
+    late MediaStream mediaStream;
+    late MediaDevices mediaDevices;
+
+    setUp(() {
+      window = MockWindow();
+      navigator = MockNavigator();
+      mediaDevices = MockMediaDevices();
+
+      final videoElement = VideoElement()
+        ..src = 'https://www.w3schools.com/tags/mov_bbb.mp4'
+        ..preload = 'true'
+        ..width = 10
+        ..height = 10;
+
+      mediaStream = videoElement.captureStream();
+
+      when(() => window.navigator).thenReturn(navigator);
+      when(() => navigator.mediaDevices).thenReturn(mediaDevices);
+      when(
+        () => mediaDevices.getUserMedia(any()),
+      ).thenAnswer((_) async => mediaStream);
+    });
+
+    group('initialize', () {
+      test(
+          'creates a video element '
+          'with correct properties', () async {
+        const audioConstraints = AudioConstraints(enabled: true);
+
+        final camera = Camera(
+          textureId: 1,
+          options: CameraOptions(
+            audio: audioConstraints,
+          ),
+          window: window,
+        );
+
+        await camera.initialize();
+
+        expect(camera.videoElement, isNotNull);
+        expect(camera.videoElement.autoplay, isFalse);
+        expect(camera.videoElement.muted, !audioConstraints.enabled);
+        expect(camera.videoElement.srcObject, mediaStream);
+        expect(camera.videoElement.attributes.keys, contains('playsinline'));
+
+        expect(camera.videoElement.style.transformOrigin, isEmpty);
+        expect(camera.videoElement.style.pointerEvents, equals('none'));
+        expect(camera.videoElement.style.width, equals('100%'));
+        expect(camera.videoElement.style.height, equals('100%'));
+        expect(camera.videoElement.style.objectFit, equals('cover'));
+        expect(camera.videoElement.style.transform, equals('scaleX(-1)'));
+      });
+
+      test(
+          'creates a wrapping div element '
+          'with correct properties', () async {
+        final camera = Camera(
+          textureId: 1,
+          window: window,
+        );
+
+        await camera.initialize();
+
+        expect(camera.divElement, isNotNull);
+        expect(camera.divElement.style.objectFit, equals('cover'));
+        expect(camera.divElement.children, contains(camera.videoElement));
+      });
+
+      test('calls getUserMedia with provided options', () async {
+        const options = CameraOptions(
+          video: VideoConstraints(enabled: false),
+        );
+
+        final optionsJson = await options.toJson();
+
+        final camera = Camera(
+          textureId: 1,
+          options: options,
+          window: window,
+        );
+
+        await camera.initialize();
+
+        verify(() => mediaDevices.getUserMedia(optionsJson)).called(1);
+      });
+
+      group('throws CameraException', () {
+        test(
+            'containing notSupported error '
+            'when there are no media devices', () {
+          when(() => navigator.mediaDevices).thenReturn(null);
+
+          final camera = Camera(
+            textureId: 1,
+            window: window,
+          );
+
+          expect(
+            camera.initialize,
+            throwsA(
+              isA<CameraException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCodes.notSupported,
+              ),
+            ),
+          );
+        });
+
+        test(
+            'containing notFound error '
+            'when getUserMedia throws DomException '
+            'with NotFoundError', () {
+          when(() => mediaDevices.getUserMedia(any()))
+              .thenThrow(FakeDomException('NotFoundError'));
+
+          final camera = Camera(
+            textureId: 1,
+            window: window,
+          );
+
+          expect(
+            camera.initialize,
+            throwsA(
+              isA<CameraException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCodes.notFound,
+              ),
+            ),
+          );
+        });
+
+        test(
+            'containing notFound error '
+            'when getUserMedia throws DomException '
+            'with DevicesNotFoundError', () {
+          when(() => mediaDevices.getUserMedia(any()))
+              .thenThrow(FakeDomException('DevicesNotFoundError'));
+
+          final camera = Camera(
+            textureId: 1,
+            window: window,
+          );
+
+          expect(
+            camera.initialize,
+            throwsA(
+              isA<CameraException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCodes.notFound,
+              ),
+            ),
+          );
+        });
+
+        test(
+            'containing notReadable error '
+            'when getUserMedia throws DomException '
+            'with NotReadableError', () {
+          when(() => mediaDevices.getUserMedia(any()))
+              .thenThrow(FakeDomException('NotReadableError'));
+
+          final camera = Camera(
+            textureId: 1,
+            window: window,
+          );
+
+          expect(
+            camera.initialize,
+            throwsA(
+              isA<CameraException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCodes.notReadable,
+              ),
+            ),
+          );
+        });
+
+        test(
+            'containing notReadable error '
+            'when getUserMedia throws DomException '
+            'with TrackStartError', () {
+          when(() => mediaDevices.getUserMedia(any()))
+              .thenThrow(FakeDomException('TrackStartError'));
+
+          final camera = Camera(
+            textureId: 1,
+            window: window,
+          );
+
+          expect(
+            camera.initialize,
+            throwsA(
+              isA<CameraException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCodes.notReadable,
+              ),
+            ),
+          );
+        });
+
+        test(
+            'containing overconstrained error '
+            'when getUserMedia throws DomException '
+            'with OverconstrainedError', () {
+          when(() => mediaDevices.getUserMedia(any()))
+              .thenThrow(FakeDomException('OverconstrainedError'));
+
+          final camera = Camera(
+            textureId: 1,
+            window: window,
+          );
+
+          expect(
+            camera.initialize,
+            throwsA(
+              isA<CameraException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCodes.overconstrained,
+              ),
+            ),
+          );
+        });
+
+        test(
+            'containing overconstrained error '
+            'when getUserMedia throws DomException '
+            'with ConstraintNotSatisfiedError', () {
+          when(() => mediaDevices.getUserMedia(any()))
+              .thenThrow(FakeDomException('ConstraintNotSatisfiedError'));
+
+          final camera = Camera(
+            textureId: 1,
+            window: window,
+          );
+
+          expect(
+            camera.initialize,
+            throwsA(
+              isA<CameraException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCodes.overconstrained,
+              ),
+            ),
+          );
+        });
+
+        test(
+            'containing permissionDenied error '
+            'when getUserMedia throws DomException '
+            'with NotAllowedError', () {
+          when(() => mediaDevices.getUserMedia(any()))
+              .thenThrow(FakeDomException('NotAllowedError'));
+
+          final camera = Camera(
+            textureId: 1,
+            window: window,
+          );
+
+          expect(
+            camera.initialize,
+            throwsA(
+              isA<CameraException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCodes.permissionDenied,
+              ),
+            ),
+          );
+        });
+
+        test(
+            'containing permissionDenied error '
+            'when getUserMedia throws DomException '
+            'with PermissionDeniedError', () {
+          when(() => mediaDevices.getUserMedia(any()))
+              .thenThrow(FakeDomException('PermissionDeniedError'));
+
+          final camera = Camera(
+            textureId: 1,
+            window: window,
+          );
+
+          expect(
+            camera.initialize,
+            throwsA(
+              isA<CameraException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCodes.permissionDenied,
+              ),
+            ),
+          );
+        });
+
+        test(
+            'containing type error '
+            'when getUserMedia throws DomException '
+            'with TypeError', () {
+          when(() => mediaDevices.getUserMedia(any()))
+              .thenThrow(FakeDomException('TypeError'));
+
+          final camera = Camera(
+            textureId: 1,
+            window: window,
+          );
+
+          expect(
+            camera.initialize,
+            throwsA(
+              isA<CameraException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCodes.type,
+              ),
+            ),
+          );
+        });
+
+        test(
+            'containing unknown error '
+            'when getUserMedia throws DomException '
+            'with an unknown error', () {
+          when(() => mediaDevices.getUserMedia(any()))
+              .thenThrow(FakeDomException('Unknown'));
+
+          final camera = Camera(
+            textureId: 1,
+            window: window,
+          );
+
+          expect(
+            camera.initialize,
+            throwsA(
+              isA<CameraException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCodes.unknown,
+              ),
+            ),
+          );
+        });
+
+        test(
+            'containing unknown error '
+            'when getUserMedia throws an unknown exception', () {
+          when(() => mediaDevices.getUserMedia(any())).thenThrow(Exception());
+
+          final camera = Camera(
+            textureId: 1,
+            window: window,
+          );
+
+          expect(
+            camera.initialize,
+            throwsA(
+              isA<CameraException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCodes.unknown,
+              ),
+            ),
+          );
+        });
+      });
+    });
+
+    group('play', () {
+      test('starts playing the video element', () async {
+        var startedPlaying = false;
+
+        final camera = Camera(
+          textureId: 1,
+          window: window,
+        );
+
+        await camera.initialize();
+
+        camera.videoElement.onPlay.listen((event) => startedPlaying = true);
+
+        await camera.play();
+
+        expect(startedPlaying, isTrue);
+      });
+
+      test(
+          'assigns media stream to the video element\'s source '
+          'if it does not exist', () async {
+        final camera = Camera(
+          textureId: 1,
+          window: window,
+        );
+
+        await camera.initialize();
+
+        /// Remove the video element's source
+        /// by stopping the camera.
+        // ignore: cascade_invocations
+        camera.stop();
+
+        await camera.play();
+
+        expect(camera.videoElement.srcObject, mediaStream);
+      });
+    });
+
+    group('stop', () {
+      test('resets the video element\'s source', () async {
+        final camera = Camera(
+          textureId: 1,
+          window: window,
+        );
+
+        await camera.initialize();
+        await camera.play();
+
+        camera.stop();
+
+        expect(camera.videoElement.srcObject, isNull);
+      });
+    });
+
+    group('takePicture', () {
+      test('returns a captured picture', () async {
+        final camera = Camera(
+          textureId: 1,
+          window: window,
+        );
+
+        await camera.initialize();
+        await camera.play();
+
+        final pictureFile = await camera.takePicture();
+
+        expect(pictureFile, isNotNull);
+      });
+    });
+
+    group('dispose', () {
+      test('resets the video element\'s source', () async {
+        final camera = Camera(
+          textureId: 1,
+          window: window,
+        );
+
+        await camera.initialize();
+
+        camera.dispose();
+
+        expect(camera.videoElement.srcObject, isNull);
+      });
+    });
+  });
+}

--- a/packages/camera/camera_web/test/src/camera_test.dart
+++ b/packages/camera/camera_web/test/src/camera_test.dart
@@ -26,7 +26,8 @@ void main() {
       mediaDevices = MockMediaDevices();
 
       final videoElement = VideoElement()
-        ..src = 'https://www.w3schools.com/tags/mov_bbb.mp4'
+        ..src =
+            'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4'
         ..preload = 'true'
         ..width = 10
         ..height = 10;

--- a/packages/camera/camera_web/test/src/camera_web_test.dart
+++ b/packages/camera/camera_web/test/src/camera_web_test.dart
@@ -1,20 +1,17 @@
 @TestOn('chrome')
 
 import 'dart:html';
+
 import 'package:camera_platform_interface/camera_platform_interface.dart';
 import 'package:camera_web/camera_web.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
-class MockWindow extends Mock implements Window {}
-
-class MockNavigator extends Mock implements Navigator {}
-
-class MockMediaDevices extends Mock implements MediaDevices {}
+import '../helpers/helpers.dart';
 
 void main() {
-  group('Camera', () {
+  group('CameraPlugin', () {
     const cameraId = 0;
 
     late Window window;


### PR DESCRIPTION
## Description

- Added a web camera with options to play, stop and take a picture. 
- Update camera exceptions to throw `CameraException` with appropriate error codes rather than introducing new exception types [as here](https://github.com/VGVentures/photobooth/blob/main/packages/camera/camera_platform_interface/lib/src/types/camera_exception.dart). This is to stay consistent with the current camera plugin.
- Updated `takePicture` to return an `XFile` rather than photobooth's [`CameraImage`](https://github.com/VGVentures/photobooth/blob/main/packages/camera/camera_platform_interface/lib/src/types/camera_image.dart).

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
